### PR TITLE
Change default shortcut for show/hide

### DIFF
--- a/src/shortcutConfig.js
+++ b/src/shortcutConfig.js
@@ -88,7 +88,7 @@ class ShortcutConfig {
     getDefaultConfig() {
         return {
             'quick-add': 'CommandOrControl+Alt+a',
-            'show-hide': 'CommandOrControl+Alt+t',
+            'show-hide': 'CommandOrControl+Alt+Q',
             'refresh': 'CommandOrControl+Alt+r'
         }
     }


### PR DESCRIPTION
`Ctrl+Alt+T` is the often shortcut for the system terminal app. `Ctrl+Alt+Q` seems to be a more friendly default. See #23.

Closes #23.