### PR TITLE
add makefile command to setup env on new git clone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ DIST_DIR=dist
 VERSION=1.15.0
 DROPBOX_DIR=~/Dropbox/projects/binaries
 
+.PHONY: env
+env:
+	@npm install && cd src && npm install && echo "\nAll development dependencies have been installed successfully!\n"
+	
 .PHONY: up
 up:
 	cd src && npm start


### PR DESCRIPTION
adds a simple makefile target. after a new git clone users can simply run `make env` to pull all dependencies and make it ready to run.