### PR TITLE
multiple fixes for makefile and issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ DIST_DIR=dist
 VERSION=1.15.0
 DROPBOX_DIR=~/Dropbox/projects/binaries
 
+.PHONY: env
+env:
+	@npm install && cd src && npm install && echo "\nAll development dependencies have been installed successfully!\n"
+
 .PHONY: up
 up:
 	cd src && npm start

--- a/Makefile
+++ b/Makefile
@@ -9,21 +9,21 @@ env:
 .PHONY: up
 up:
 	cd src && npm start
-
+	
 .PHONY: build-rpm
-build-all:
+build-rpm:
 	./node_modules/.bin/electron-builder --linux rpm
 
 .PHONY: build-deb
-build-all:
+build-deb:
 	./node_modules/.bin/electron-builder --linux deb
 
 .PHONY: build-win
-build-all:
+build-win:
 	./node_modules/.bin/electron-builder --win
 
 .PHONY: build-linux
-build-all:
+build-linux:
 	./node_modules/.bin/electron-builder --linux
 
 .PHONY: build-all

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,22 @@ env:
 up:
 	cd src && npm start
 
+.PHONY: build-rpm
+build-all:
+	./node_modules/.bin/electron-builder --linux rpm
+
+.PHONY: build-deb
+build-all:
+	./node_modules/.bin/electron-builder --linux deb
+
+.PHONY: build-win
+build-all:
+	./node_modules/.bin/electron-builder --win
+
+.PHONY: build-linux
+build-all:
+	./node_modules/.bin/electron-builder --linux
+
 .PHONY: build-all
 build-all:
 	./node_modules/.bin/electron-builder --linux && \

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ The build process is very simple:
 
 That's all. Now to run the app you can use `make up` command (in root folder) or `npm start` (in `src` directory).
 
-There is also `make build-all` target. Check it out if you're interesting in building DEB or RPM package.
+For building 64-bit dist packages:
+
+1. `make build-rpm` to build rpm packages (for Fedora/CentOS/RHEL/SuSE)
+2. `make build-deb` to build deb packages (for Debian/Ubuntu and derivatives)
+3. `make build-win` to build windows executable
+4. `make build-linux` to build both DEB and RPM packages
+5. `make build-all` to build packages for both Windows and Linux
 
 No rules for contributing. Just sent a pull request.

--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ Contribute/Build
 
 The build process is very simple:
 
-* run `npm install` in root folder
-* run `npm install` in `src` folder
+* run `make env` in project root folder
 
 That's all. Now to run the app you can use `make up` command (in root folder) or `npm start` (in `src` directory).
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
         }
     },
     "devDependencies": {
-        "electron-builder": "^20.10.0"
+        "electron-builder": "^20.39.0"
     }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,7 @@ const shortcuts = require('./shortcuts');
 let win = {};
 let gOauthWindow = undefined;
 let tray = null;
+let contextMenu;
 
 function handleRedirect(e, url) {
     // there may be some popups on the same page
@@ -53,11 +54,19 @@ function handleRedirect(e, url) {
 
 function createTray(win) {
     tray = new Tray(path.join(__dirname, 'icons/icon.png'));
-    const contextMenu = Menu.buildFromTemplate([
+    contextMenu = Menu.buildFromTemplate([
       {
         label: 'Show', click:  function() {
           win.show();
-        }
+        },
+        enabled: false,
+        id: 'show-win'
+      },
+      {
+        label: 'Hide', click:  function() {
+          win.hide();
+        },
+        id: 'hide-win'
       },
       {
         label: 'Toggle FullScreen', click:  function() {
@@ -124,10 +133,16 @@ function createWindow () {
 
     win.on('hide', function() {
         win['currentWindowState'] = 'hidden';
+        contextMenu.getMenuItemById('show-win').enabled = true;
+        contextMenu.getMenuItemById('hide-win').enabled = false;
+        tray.setContextMenu(contextMenu);
     });
 
     win.on('show', function() {
         win['currentWindowState'] = 'shown';
+        contextMenu.getMenuItemById('show-win').enabled = false;
+        contextMenu.getMenuItemById('hide-win').enabled = true;
+        tray.setContextMenu(contextMenu);
     });
 
     win.webContents.on('new-window', handleRedirect)

--- a/src/package.json
+++ b/src/package.json
@@ -15,8 +15,8 @@
   "author": "Ruslan Bekenev <furyinbox@gmail.com>",
   "license": "ISC",
   "devDependencies": {
-    "electron": "^4.0.5",
-    "electron-packager": "^13.1.0"
+    "electron": "^4.1.0",
+    "electron-packager": "^13.1.1"
   },
   "dependencies": {
     "electron-window-state": "^5.0.3"


### PR DESCRIPTION
This PR has 5 commits

1) add new makefile target `env` so that users can simply do `git clone ...` and then `make env` to install all dependencies.

2) fix #34 by adding makefile targets to build for individual platforms

4) fix #29 (partial fix)

5) updates `electron-builder` and `electron` (minor version updates)

I've tested and verified these changes on my Fedora 29 host. 