### PR TITLE
Implemented bringing window to front if it is in background (closes #44)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -112,8 +112,6 @@ function createWindow () {
         slashes: true
     }));
 
-    win['currentWindowState'] = 'shown';
-
     createTray(win);
     shortcutsInstance = new shortcuts(win, app);
     shortcutsInstance.registerAllShortcuts();
@@ -134,14 +132,12 @@ function createWindow () {
     });
 
     win.on('hide', function() {
-        win['currentWindowState'] = 'hidden';
         contextMenu.getMenuItemById('show-win').enabled = true;
         contextMenu.getMenuItemById('hide-win').enabled = false;
         tray.setContextMenu(contextMenu);
     });
 
     win.on('show', function() {
-        win['currentWindowState'] = 'shown';
         contextMenu.getMenuItemById('show-win').enabled = false;
         contextMenu.getMenuItemById('hide-win').enabled = true;
         tray.setContextMenu(contextMenu);

--- a/src/shortcuts.js
+++ b/src/shortcuts.js
@@ -29,11 +29,12 @@ class shortcuts {
     // show/hide
     registerShowHideShortcut() {
         globalShortcut.register(this.shortcutConfig.config['show-hide'], () => {
-            if (this.win.currentWindowState == 'hidden') {
+            if (!this.win.isFocused()) {
                 this.win.show();
+                this.win.focus();
                 return;
             }
-
+            
             this.win.hide();
         });
     }
@@ -41,7 +42,7 @@ class shortcuts {
     // reload page
     registerReloadShortcut() {
         globalShortcut.register(this.shortcutConfig.config['refresh'], () => {
-            if (this.win.currentWindowState == 'shown') {
+            if (this.win.isFocused()) {
                 this.win.reload();
             }
         });


### PR DESCRIPTION
This PR gets rid of `currentWindowStatus` in favor of the `isFocused()` method. By doing this it also allows for bringing the window to front if it is currently in the background as described in #44.