### PR TITLE
Implemented option to opt into Todoist Beta

### DIFF
--- a/src/beta.html
+++ b/src/beta.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>Todoist</title>
+        <title>Todoist Beta</title>
         <meta charset="utf-8">
         <link rel="stylesheet" type="text/css" href="main.css">
     </head>

--- a/src/beta.html
+++ b/src/beta.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Todoist</title>
+        <meta charset="utf-8">
+        <link rel="stylesheet" type="text/css" href="main.css">
+    </head>
+    <body>
+        <iframe id="view" src="https://beta.todoist.com/app"></iframe>
+    </body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -122,8 +122,8 @@ function createWindow () {
 
     // and load the index.html of the app.
     win.loadURL(url.format({
-      pathname: path.join(__dirname, (config['beta'] ? 'beta.html' : 'index.html')),
-      protocol: 'file:',
+        pathname: path.join(__dirname, (config['beta'] ? 'beta.html' : 'index.html')),
+        protocol: 'file:',
         slashes: true
     }));
 

--- a/src/main.js
+++ b/src/main.js
@@ -122,8 +122,8 @@ function createWindow () {
 
     // and load the index.html of the app.
     win.loadURL(url.format({
-        pathname: path.join(__dirname, 'index.html'),
-        protocol: 'file:',
+      pathname: path.join(__dirname, (config['beta'] ? 'beta.html' : 'index.html')),
+      protocol: 'file:',
         slashes: true
     }));
 

--- a/src/shortcutConfig.js
+++ b/src/shortcutConfig.js
@@ -90,6 +90,7 @@ class ShortcutConfig {
             'quick-add': 'CommandOrControl+Alt+a',
             'show-hide': 'CommandOrControl+Alt+Q',
             'refresh': 'CommandOrControl+Alt+r',
+            'beta': false,
             'quit': 'Alt+F4',
             'tray-icon': 'icon.png',
         }


### PR DESCRIPTION
Implements the feature I've requested in #68. Works by using a ternary operator to switch between `index.html` and `beta.html` based on the boolean value of `beta` in `.todoist-linix.json`. `beta.html` is nearly identical to `index.html` except for a change in the Todoist iframe URL from `todoist.com/app` to `beta.todoist.com/app`.