### PR TITLE
Adds autofocus to the quick add modal 

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,5 +7,14 @@
     </head>
     <body>
         <iframe id="view" src="https://todoist.com/app"></iframe>
+        <script>
+            // Autofocus the quick add text section.
+
+            const {ipcRenderer} = require('electron');
+            ipcRenderer.on('focus-quick-add', () => {
+                const frameWindow = document.getElementsByTagName('iframe')[0].contentWindow;
+                frameWindow.document.getElementsByClassName('public-DraftEditor-content')[0].focus()
+            })
+        </script>
     </body>
 </html>

--- a/src/shortcuts.js
+++ b/src/shortcuts.js
@@ -23,6 +23,7 @@ class shortcuts {
                 keyCode: 'q'
             });
             this.win.show();
+            this.win.webContents.send('focus-quick-add');
         });
     }
 


### PR DESCRIPTION
Just started using Todoist today and immediately wanted to install it on every device I own  :smile: 

I came across a weird focus handling bug when using the quick add global key event.
Instead of focusing on the text input, it went directly to the schedule section.

![image](https://user-images.githubusercontent.com/6024132/78307729-dd595080-7546-11ea-9959-afc64ca58087.png)

I'm using Ubuntu 18.04 so I don't know if this is a problem on other distros too but it seems like #53 should be fixed too. (I couldn't reproduce the behavior)
