### PR TITLE
Update quick-add shortcut to send 'Escape' keydown before 'q'

### DIFF
--- a/src/shortcuts.js
+++ b/src/shortcuts.js
@@ -19,6 +19,10 @@ class shortcuts {
   registerQuickAddShortcut() {
     globalShortcut.register(this.shortcutConfig.config['quick-add'], () => {
       this.win.webContents.sendInputEvent({
+        type: "keyDown",
+        keyCode: "Escape"
+      });
+      this.win.webContents.sendInputEvent({
         type: "char",
         keyCode: 'q'
       });


### PR DESCRIPTION
Before this change, if a new task input was already open, then this shortcut would type a literal "q" into that input rather than opening Todoist's quick add dialog. By sending an "Escape" keydown event first, any such inputs will first close, and the quick add will be correctly shown.

Fixes #83 