### PR TITLE
Add missing `-e` option to the `echo` command in `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DROPBOX_DIR=~/Dropbox/projects/binaries
 
 .PHONY: env
 env:
-	@npm install && cd src && npm install && echo "\nAll development dependencies have been installed successfully!\n"
+	@npm install && cd src && npm install && echo -e "\nAll development dependencies have been installed successfully!\n"
 
 .PHONY: up
 up:


### PR DESCRIPTION
In [`Makefile` (L7)](https://github.com/KryDos/todoist-linux/blob/master/Makefile#L7), you are missing `-e` option from the `echo` command, therefore the newline characters are output as strings (`\n`).