### PR TITLE
Fix typos

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -138,7 +138,7 @@ function createWindow () {
   shortcutsInstance = new shortcuts(win, app);
   shortcutsInstance.registerAllShortcuts();
 
-  // react on close and minimzie
+  // react on close and minimize
   win.on('minimize',function(event){
     event.preventDefault();
     win.hide();

--- a/src/main.js
+++ b/src/main.js
@@ -86,7 +86,7 @@ function createTray(win) {
     {
       label: 'Quit',
       click:  function() {
-        app.isQuiting = true;
+        app.isQuitting = true;
         app.quit();
       }
     }
@@ -148,10 +148,10 @@ function createWindow () {
     // we should not hide the window if there is no tray icon
     // because user will not be able to close the app
     if (!config['tray-icon']) {
-      app.isQuiting = true;
+      app.isQuitting = true;
     }
 
-    if(!app.isQuiting){
+    if(!app.isQuitting){
       event.preventDefault();
       win.hide();
     }

--- a/src/shortcuts.js
+++ b/src/shortcuts.js
@@ -59,10 +59,10 @@ class shortcuts {
 
   registerQuitShortcut() {
     globalShortcut.register(this.shortcutConfig.config['quit'], () => {
-      // isQuiting is important for
+      // isQuitting is important for
       // on('close') event where this variable is checked.
       // In case it is not true then the app just minimized.
-      this.app.isQuiting = true;
+      this.app.isQuitting = true;
       this.app.quit();
     });
   }


### PR DESCRIPTION
Fixes minor typos on comments and an app object property

I tested the affected code manually by closing the app trought the button and the ALT + F4 shortcut