### PR TITLE
In app settings

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -19,41 +19,6 @@ let tray = null;
 let contextMenu;
 let config = {};
 
-function handleRedirect(e, url) {
-  // there may be some popups on the same page
-  if(url == win.webContents.getURL()) {
-    return true;
-  }
-
-  // when user is logged in there is link
-  // asks to update the page. It should be opened
-  // in the app and not in the external browser
-  if (/https:\/\/todoist\.com\/app/.test(url)) {
-    win.reload();
-    return true;
-  }
-
-  /**
-   * In case of google or facebook oauth login
-   * let's create another window and listen for
-   * its "close" event.
-   * As soon as that event fired we can refresh our
-   * main window.
-   */
-  if (/google.+?oauth/.test(url) || /facebook.+?oauth/.test(url)) {
-    e.preventDefault();
-    gOauthWindow = new BrowserWindow();
-    gOauthWindow.loadURL(url);
-    gOauthWindow.on('close', () => {
-      win.reload();
-    })
-    return true;
-  }
-
-  e.preventDefault()
-  shell.openExternal(url)
-}
-
 function createTray(win) {
   // if tray-icon is set to null in config file then don't create a tray icon
   if (!config['tray-icon']) {
@@ -175,6 +140,41 @@ function createWindow () {
   // manage size/positio of the window
   // so it can be restore next time
   mainWindowState.manage(win);
+}
+
+function handleRedirect(e, url) {
+  // there may be some popups on the same page
+  if (url == win.webContents.getURL()) {
+    return true;
+  }
+
+  // when user is logged in there is link
+  // asks to update the page. It should be opened
+  // in the app and not in the external browser
+  if (/https:\/\/todoist\.com\/app/.test(url)) {
+    win.reload();
+    return true;
+  }
+
+  /**
+   * In case of google or facebook oauth login
+   * let's create another window and listen for
+   * its "close" event.
+   * As soon as that event fired we can refresh our
+   * main window.
+   */
+  if (/google.+?oauth/.test(url) || /facebook.+?oauth/.test(url)) {
+    e.preventDefault();
+    gOauthWindow = new BrowserWindow();
+    gOauthWindow.loadURL(url);
+    gOauthWindow.on('close', () => {
+      win.reload();
+    })
+    return true;
+  }
+
+  e.preventDefault()
+  shell.openExternal(url)
 }
 
 var gotTheLock = app.requestSingleInstanceLock();

--- a/src/main.js
+++ b/src/main.js
@@ -173,6 +173,19 @@ function handleRedirect(e, url) {
     return true;
   }
 
+  /*
+   * The first time the settings button is clicked 
+   * the 'new-window' event is emitted with the url to the settings page
+   * The electron default behavior(creating a new window) is prevented 
+   * and instead the contents of the main window are reloaded with the contents 
+   * from the settings page effectively emulating the behavior of the website
+   */
+  if (/prefs\/account/.test(url)) {
+    e.preventDefault();
+    win.loadURL(url);
+    return true;
+  }
+
   e.preventDefault()
   shell.openExternal(url)
 }


### PR DESCRIPTION
Potential development for #88 

Tested on Ubuntu 20.04

Previous to this PR the app would open the settings page on a browser window which would unecessarily shift the focus of the user. 
To solve this it was suggested that the settings page would be presented _in-app_.
To enable that we capture the event that is emitted when the settings button is clicked and render the contents of the Todoist settings page in the main electron window.