### PR TITLE
Improvement: minimize & close to tray config options

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -112,18 +112,13 @@ function createWindow () {
   });
 
   win.on('close', function (event) {
-    // we should not hide the window if there is no tray icon
-    // because user will not be able to close the app
-    if (!config['tray-icon']) {
-      app.isQuitting = true;
+    if (app.isQuitting || !config['tray-icon'] || !config['close-to-tray']) {  
+      // Do the default electron behaviour which is to close the main window
+      return;
     }
 
-    if(!app.isQuitting){
-      event.preventDefault();
-      win.hide();
-    }
-
-    return false;
+    event.preventDefault();
+    win.hide();
   });
 
   win.on('hide', function() {

--- a/src/main.js
+++ b/src/main.js
@@ -51,7 +51,7 @@ function createTray(win) {
     {
       label: 'Quit',
       click:  function() {
-        app.isQuitting = true;
+        app.forceQuit = true;
         app.quit();
       }
     }
@@ -112,7 +112,7 @@ function createWindow () {
   });
 
   win.on('close', function (event) {
-    if (app.isQuitting || !config['tray-icon'] || !config['close-to-tray']) {  
+    if (app.forceQuit || !config['tray-icon'] || !config['close-to-tray']) {  
       // Do the default electron behaviour which is to close the main window
       return;
     }

--- a/src/main.js
+++ b/src/main.js
@@ -103,10 +103,12 @@ function createWindow () {
   shortcutsInstance = new shortcuts(win, app);
   shortcutsInstance.registerAllShortcuts();
 
-  // react on close and minimize
-  win.on('minimize',function(event){
-    event.preventDefault();
-    win.hide();
+  // Only send to tray on minimize if user is running with tray and minimizing to tray is allowed
+  win.on('minimize',function(event) {
+    if (config['tray-icon'] && config['minimize-to-tray']) {
+      event.preventDefault();
+      win.hide();
+    }
   });
 
   win.on('close', function (event) {

--- a/src/shortcutConfig.js
+++ b/src/shortcutConfig.js
@@ -94,6 +94,7 @@ class ShortcutConfig {
       'quit': 'Alt+F4',
       'tray-icon': 'icon.png',
       'minimize-to-tray': true,
+      'close-to-tray': true,
     }
   }
 }

--- a/src/shortcutConfig.js
+++ b/src/shortcutConfig.js
@@ -93,6 +93,7 @@ class ShortcutConfig {
       'beta': false,
       'quit': 'Alt+F4',
       'tray-icon': 'icon.png',
+      'minimize-to-tray': true,
     }
   }
 }

--- a/src/shortcuts.js
+++ b/src/shortcuts.js
@@ -63,10 +63,8 @@ class shortcuts {
         return;
       }
 
-      // isQuitting is important for
-      // on('close') event where this variable is checked.
-      // In case it is not true then the app just minimized.
-      this.app.isQuitting = true;
+      // forceQuit is important for on('close') event where this variable is checked.
+      this.app.forceQuit = true;
       this.app.quit();
     });
   }


### PR DESCRIPTION
Added config options to control the behavior of the minimize and close button.
The user can now choose whether the app minimizes or closes to the tray. 

Both these options are only valid when the user has enabled the tray icon using the config option `tray-icon` in the config file otherwise the minimize and close buttons assume the default Electron behavior which is to minimize and close the main window, respectively.

These options can be set in the config file(`~/.config/.todoist-linux.json`), for example:
```JSON

{
    "quit": "Alt+F4",
    "tray-icon": "icon.png",
    "minimize-to-tray": true,
    "close-to-tray": false
}
```
Tested **manually** on Ubuntu 20.04 using GNOME.