### PR TITLE
Improved context/tray menu.

### DIFF
--- a/src/beta.html
+++ b/src/beta.html
@@ -8,12 +8,17 @@
     <body>
         <iframe id="view" src="https://beta.todoist.com/app"></iframe>
         <script>
-            // Autofocus the quick add text section.
-
             const {ipcRenderer} = require('electron');
+
+            // Autofocus the quick add text section.
             ipcRenderer.on('focus-quick-add', () => {
                 const frameWindow = document.getElementsByTagName('iframe')[0].contentWindow;
                 frameWindow.document.getElementsByClassName('public-DraftEditor-content')[0].focus()
+            })
+
+            ipcRenderer.on('go-to-anchor', function (event, filter) {
+                const frameWindow = document.getElementById('view').contentWindow;
+                frameWindow.document.getElementById(filter).click();
             })
         </script>
     </body>

--- a/src/index.html
+++ b/src/index.html
@@ -8,12 +8,17 @@
     <body>
         <iframe id="view" src="https://todoist.com/app"></iframe>
         <script>
-            // Autofocus the quick add text section.
-
             const {ipcRenderer} = require('electron');
+
+            // Autofocus the quick add text section.
             ipcRenderer.on('focus-quick-add', () => {
                 const frameWindow = document.getElementsByTagName('iframe')[0].contentWindow;
                 frameWindow.document.getElementsByClassName('public-DraftEditor-content')[0].focus()
+            })
+
+            ipcRenderer.on('go-to-anchor', function (event, filter) {
+                const frameWindow = document.getElementById('view').contentWindow;
+                frameWindow.document.getElementById(filter).click();
             })
         </script>
     </body>

--- a/src/main.js
+++ b/src/main.js
@@ -19,22 +19,6 @@ let tray = null;
 let contextMenu;
 let config = {};
 
-// const CONFIG_FILE_NAME = '.todoist-linux.json'
-
-// function getConfigDirectory() {
-//   if (process.platform == 'win32') {
-//     return process.env.HOMEDRIVE + process.env.HOMEPATH;
-//   }
-
-//   // if possible save config in $XDG_CONFIG_HOME
-//   // which is $HOME/.config by default
-//   if (process.env.XDG_CONFIG_HOME) {
-//     return process.env.XDG_CONFIG_HOME;
-//   }
-
-//   return process.env.HOME + '/.config';
-// }
-
 function createTray(win) {
   const configInstance = new ShortcutConfig();
 

--- a/src/main.js
+++ b/src/main.js
@@ -19,7 +19,25 @@ let tray = null;
 let contextMenu;
 let config = {};
 
+// const CONFIG_FILE_NAME = '.todoist-linux.json'
+
+// function getConfigDirectory() {
+//   if (process.platform == 'win32') {
+//     return process.env.HOMEDRIVE + process.env.HOMEPATH;
+//   }
+
+//   // if possible save config in $XDG_CONFIG_HOME
+//   // which is $HOME/.config by default
+//   if (process.env.XDG_CONFIG_HOME) {
+//     return process.env.XDG_CONFIG_HOME;
+//   }
+
+//   return process.env.HOME + '/.config';
+// }
+
 function createTray(win) {
+  const configInstance = new ShortcutConfig();
+
   // if tray-icon is set to null in config file then don't create a tray icon
   if (!config['tray-icon']) {
     return;
@@ -28,32 +46,108 @@ function createTray(win) {
   tray = new Tray(path.join(__dirname, `icons/${config['tray-icon']}`));
   contextMenu = Menu.buildFromTemplate([
     {
-      label: 'Show',
+      label: 'Open Todoist',
       click:  function() {
         win.show();
       },
-      enabled: false,
       id: 'show-win'
     },
     {
-      label: 'Hide',
-      click:  function() {
-        win.hide();
-      },
-      id: 'hide-win'
+      type: 'separator'
     },
     {
-      label: 'Toggle FullScreen',
+      label: 'Add task',
       click:  function() {
-        win.setFullScreen(!win.isFullScreen());
+        win.webContents.sendInputEvent({
+          type: "keyDown",
+          keyCode: "Escape"
+        });
+        win.webContents.sendInputEvent({
+          type: "keyUp",
+          keyCode: "Escape"
+        });
+        win.webContents.sendInputEvent({
+          type: "char",
+          keyCode: 'q'
+        });
+        win.show();
+        win.webContents.send('focus-quick-add');
       },
+      id: 'add-task'
     },
     {
-      label: 'Quit',
+      label: 'Search',
+      click:  function() {
+        win.webContents.sendInputEvent({
+          type: "keyDown",
+          keyCode: "Escape"
+        });
+        win.webContents.sendInputEvent({
+          type: "keyUp",
+          keyCode: "Escape"
+        });
+        win.webContents.sendInputEvent({
+          type: "char",
+          keyCode: 'f'
+        });
+        win.show();
+      },
+      id: 'search'
+    },
+    {
+      label: 'Inbox',
+      click:  function() {
+        win.show();
+        win.webContents.send('go-to-anchor', 'filter_inbox');
+      },
+      id: 'inbox'
+    },
+    {
+      label: 'Today',
+      click:  function() {
+        win.show();
+        win.webContents.send('go-to-anchor', 'filter_today');
+      },
+      id: 'today'
+    },
+    {
+      label: 'Upcoming',
+      click:  function() {
+        win.show();
+        win.webContents.send('go-to-anchor', 'filter_upcoming');
+      },
+      id: 'upcoming'
+    },
+    {
+      type: 'separator'
+    },
+    {
+      label: 'Preferences',
+      click:  function() {
+        shell.openItem(path.join(
+          configInstance.getConfigDirectory(),
+          '.todoist-linux.json'
+        ));
+      },
+      id: 'preferences'
+    },
+    {
+      label: 'Report an issue',
+      click:  function() {
+        shell.openExternal('https://github.com/KryDos/todoist-linux/issues/new');
+      },
+      id: 'report-issue'
+    },
+    {
+      type: 'separator'
+    },
+    {
+      label: 'Quit Todoist',
       click:  function() {
         app.isQuitting = true;
         app.quit();
-      }
+      },
+      id: 'quit'
     }
   ]);
   tray.setToolTip('Todoist');
@@ -124,19 +218,6 @@ function createWindow () {
     return false;
   });
 
-  win.on('hide', function() {
-    contextMenu.getMenuItemById('show-win').enabled = true;
-    contextMenu.getMenuItemById('hide-win').enabled = false;
-    tray.setContextMenu(contextMenu);
-  });
-
-  win.on('show', function() {
-    contextMenu.getMenuItemById('show-win').enabled = false;
-    contextMenu.getMenuItemById('hide-win').enabled = true;
-    tray.setContextMenu(contextMenu);
-  });
-
-  win.webContents.on('new-window', handleRedirect)
   // manage size/position of the window
   // so it can be restored next time
   mainWindowState.manage(win);


### PR DESCRIPTION
Made significant improvements to the context/tray menu.

The current context/tray menu provides `Toggle FullScreen`, `Show`, `Hide`, and `Quit` options. I never really found these useful (except for maybe show and quit) since this project has universal shortcut support.

This improved context/tray menu:

![Screenshot of Todoist context menu](https://i.imgur.com/Xzyh3jh.png)

- `Open` is renamed to `Open Todoist`.
- `Close` is removed.
- `Add Task`, `Search`, `Inbox`, `Today`, and `Upcoming` all interact directly either with the Todoist web app's iframe or Todoist's built-in shortcuts to make these menu items accessible.
- `Preferences` will use the OS's default text editor to open `.todoist-linux.json`.
- `Report an issue` will open https://github.com/KryDos/todoist-linux/issues/new in the OS's default browser.
- `Quit` is renamed to `Quit Todoist`.
- Separators are added for a cleaner look.

IMHO, this PR makes the context/tray menu extremely useful as a lot of the options were inspired by the Todoist Android app's shortcuts.