### PR TITLE
Refactored main.js

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 4,
+  "useTabs": false
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,0 @@
-{
-  "tabWidth": 4,
-  "useTabs": false
-}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <h1 align="center">
   <img width="500px" src="assets/readme-banner.png">
 
-  ![AUR Version][aur] ![GitHub top language][gtl] ![License][l]
+![AUR Version][aur] ![GitHub top language][gtl] ![License][l]
+
 </h1>
 
 [aur]: https://img.shields.io/aur/version/todoist-electron
@@ -48,13 +49,13 @@ Alternatively, you can also download the `todoist-linux.zip` package from [Relea
 
 ## Keyboard Shortcuts
 
-- <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>A</kbd> - Quickly add a Task
-- <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Q</kbd> - Show or Hide Todoist window
-- <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>R</kbd> - Refresh Todoist window content
-- <kbd>Alt</kbd> + <kbd>F4</kbd> - Quit Todoist
-- <kbd>F11</kbd> - Toggle Full-screen view
+-   <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>A</kbd> - Quickly add a Task
+-   <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Q</kbd> - Show or Hide Todoist window
+-   <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>R</kbd> - Refresh Todoist window content
+-   <kbd>Alt</kbd> + <kbd>F4</kbd> - Quit Todoist
+-   <kbd>F11</kbd> - Toggle Full-screen view
 
-- Any other possible shortcuts are available and usable directly from within the app itself.
+-   Any other possible shortcuts are available and usable directly from within the app itself.
 
 Global shortcuts are configurable via `$XDG_CONFIG_HOME/.todoist-linux.json` file (which is located in `~/.config` by default).
 The file is simple JSON with descriptive keys and values that represents shortcuts and their keybindings.
@@ -65,9 +66,9 @@ Use [this page from Electron docs](https://electronjs.org/docs/api/accelerator#a
 
 Same config file `.todoist-linux.json` has other options to configure the app:
 
-- `tray-icon` - tray icon to use. Possible options: `icon.png`, `icon_monochrome.png`, `null` (to hide tray icon completely)
-- `minimize-to-tray` - default is `true`. When window is minimized it goes to the tray.
-- `close-to-tray` - default is `true`. When window is closed the app is minimized to the tray.
+-   `tray-icon` - tray icon to use. Possible options: `icon.png`, `icon_monochrome.png`, `null` (to hide tray icon completely)
+-   `minimize-to-tray` - default is `true`. When window is minimized it goes to the tray.
+-   `close-to-tray` - default is `true`. When window is closed the app is minimized to the tray.
 
 ## Why?
 

--- a/src/index.html
+++ b/src/index.html
@@ -2,32 +2,36 @@
 <html>
     <head>
         <title>Todoist</title>
-        <meta charset="utf-8">
-        <link rel="stylesheet" type="text/css" href="main.css">
+        <meta charset="utf-8" />
+        <link rel="stylesheet" type="text/css" href="main.css" />
     </head>
     <body>
         <iframe id="view" src="https://todoist.com/app"></iframe>
         <script>
-            const {ipcRenderer} = require('electron');
+            const { ipcRenderer } = require("electron");
 
             // Autofocus the quick add text section.
-            ipcRenderer.on('focus-quick-add', () => {
-                const frameWindow = document.getElementsByTagName('iframe')[0].contentWindow;
-                frameWindow.document.getElementsByClassName('public-DraftEditor-content')[0].focus()
-            })
+            ipcRenderer.on("focus-quick-add", () => {
+                const frameWindow = document.getElementsByTagName("iframe")[0]
+                    .contentWindow;
+                frameWindow.document
+                    .getElementsByClassName("public-DraftEditor-content")[0]
+                    .focus();
+            });
 
             // Go to a specific page in Todoist's iframe
-            ipcRenderer.on('go-to-anchor', function (event, filter) {
-                const frameWindow = document.getElementById('view').contentWindow;
+            ipcRenderer.on("go-to-anchor", function (event, filter) {
+                const frameWindow = document.getElementById("view")
+                    .contentWindow;
                 frameWindow.document.getElementById(filter).click();
-            })
+            });
 
             // Configure the page to use Todoist Beta
-            ipcRenderer.on('is-beta', () => {
-                const frameWindow = document.getElementById('view')
-                frameWindow.src = 'https://beta.todoist.com/app';
-                document.title = 'Todoist Beta';
-            })
+            ipcRenderer.on("is-beta", () => {
+                const frameWindow = document.getElementById("view");
+                frameWindow.src = "https://beta.todoist.com/app";
+                document.title = "Todoist Beta";
+            });
         </script>
     </body>
 </html>

--- a/src/main.css
+++ b/src/main.css
@@ -1,4 +1,5 @@
-html, body {
+html,
+body {
     width: 100%;
     height: 100%;
     margin: 0px;
@@ -13,13 +14,21 @@ body > .loader {
 }
 
 @keyframes blink {
-    0% { opacity: 0.1; }
-    100% { opacity: 1; }
+    0% {
+        opacity: 0.1;
+    }
+    100% {
+        opacity: 1;
+    }
 }
 
 @-webkit-keyframes blink {
-    0% { opacity: 0.1; }
-    100% { opacity: 1; }
+    0% {
+        opacity: 0.1;
+    }
+    100% {
+        opacity: 1;
+    }
 }
 
 .loader .logo {

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,6 @@
 const {
   app,
   BrowserWindow,
-  Tray,
   Menu,
   session
 } = require('electron');
@@ -12,6 +11,7 @@ const url = require('url');
 
 const {ShortcutConfig} = require('./shortcutConfig');
 const createTray = require('./tray');
+const createMenuBar = require('./menuBar');
 const shortcuts = require('./shortcuts');
 
 let win = {};
@@ -52,93 +52,7 @@ function createWindow () {
   });
 
   win.webContents.setVisualZoomLevelLimits(1, 5);
-
-  var menuBar = Menu.buildFromTemplate([
-    {
-      label: 'File',
-      submenu: [
-        {
-          label: 'Preferences',
-          click:  function() {
-            shell.openItem(path.join(
-              configInstance.getConfigDirectory(),
-              '.todoist-linux.json'
-            ));
-          },
-        },
-        {
-          label:'Quit',
-          click:  function() {
-            app.forceQuit = true;
-            app.quit();
-          },
-          accelerator: config['quit']
-        },
-      ]
-    },
-    {
-      label: 'View',
-      submenu: [
-        {
-          label:'Zoom In',
-          role: 'zoomin',
-          accelerator: 'CommandOrControl+='
-        },
-        {
-          label:'Zoom Out',
-          role: 'zoomout',
-          accelerator: 'CommandOrControl+-'
-        },
-        {
-          label:'Reset Zoom',
-          role: 'resetzoom',
-          accelerator: 'CommandOrControl+0'
-        },
-        {
-          type: 'separator'
-        },
-        {
-          label:'Show/Hide',
-          click:  function() {
-            win.hide();
-          },
-          accelerator: config['show-hide']
-        },
-        {
-          label:'Refresh',
-          click:  function() {
-            win.reload();
-          },
-          accelerator: config['refresh']
-        },
-      ]
-    },
-    {
-      label: 'Help',
-      submenu: [
-        {
-          label: 'GitHub',
-          click:  function() {
-            shell.openExternal('https://github.com/KryDos/todoist-linux');
-          },
-        },
-        {
-          label: 'Changelog',
-          click:  function() {
-            shell.openExternal('https://github.com/krydos/todoist-linux/releases');
-          },
-        },
-        {
-          label: 'Report an issue',
-          click:  function() {
-            shell.openExternal('https://github.com/KryDos/todoist-linux/issues/new');
-          },
-        },
-      ]
-    },
-  ])
-
-  Menu.setApplicationMenu(menuBar);
+  Menu.setApplicationMenu(createMenuBar(config));
 
   // and load the index.html of the app.
   win.loadURL(url.format({

--- a/src/main.js
+++ b/src/main.js
@@ -1,172 +1,120 @@
-const {
-  app,
-  BrowserWindow,
-  Menu,
-  session
-} = require('electron');
-const windowStateKeeper = require('electron-window-state');
-const shell = require('electron').shell;
-const path = require('path');
-const url = require('url');
+const { app, BrowserWindow, Menu, session } = require("electron");
+const windowStateKeeper = require("electron-window-state");
+const shell = require("electron").shell;
+const path = require("path");
+const url = require("url");
 
-const {ShortcutConfig} = require('./shortcutConfig');
-const createTray = require('./tray');
-const createMenuBar = require('./menuBar');
-const shortcuts = require('./shortcuts');
+const { ShortcutConfig } = require("./shortcutConfig");
+const createTray = require("./tray");
+const createMenuBar = require("./menuBar");
+const shortcuts = require("./shortcuts");
 
 let win = {};
 let gOauthWindow = undefined;
 let config = {};
 
-
 function setCustomUserAgent() {
-  session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
-    details.requestHeaders['User-Agent'] = 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36';
-    callback({ cancel: false, requestHeaders: details.requestHeaders });
-  });
+    session.defaultSession.webRequest.onBeforeSendHeaders(
+        (details, callback) => {
+            details.requestHeaders["User-Agent"] =
+                "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36";
+            callback({ cancel: false, requestHeaders: details.requestHeaders });
+        }
+    );
 }
 
-function createWindow () {
-  setCustomUserAgent();
+function createWindow() {
+    setCustomUserAgent();
 
-  const configInstance = new ShortcutConfig();
-  config = configInstance.config;
+    const configInstance = new ShortcutConfig();
+    config = configInstance.config;
 
-  let mainWindowState = windowStateKeeper({
-    defaultWidth: 800,
-    defaultHeight: 600
-  });
+    let mainWindowState = windowStateKeeper({
+        defaultWidth: 800,
+        defaultHeight: 600,
+    });
 
-  // use mainWindowState to restore previous
-  // size/position of window
-  win = new BrowserWindow({
-    x: mainWindowState.x,
-    y: mainWindowState.y,
-    width: mainWindowState.width,
-    height: mainWindowState.height,
-    minHeight: 600,
-    minWidth: 450,
-    title: 'Todoist',
-    icon: path.join(__dirname, 'icons/icon.png'),
-    autoHideMenuBar: true
-  });
+    // use mainWindowState to restore previous
+    // size/position of window
+    win = new BrowserWindow({
+        x: mainWindowState.x,
+        y: mainWindowState.y,
+        width: mainWindowState.width,
+        height: mainWindowState.height,
+        minHeight: 600,
+        minWidth: 450,
+        title: "Todoist",
+        icon: path.join(__dirname, "icons/icon.png"),
+        autoHideMenuBar: true,
+    });
 
-  win.webContents.setVisualZoomLevelLimits(1, 5);
-  Menu.setApplicationMenu(createMenuBar(config));
+    win.webContents.setVisualZoomLevelLimits(1, 5);
+    Menu.setApplicationMenu(createMenuBar(config));
 
-  // and load the index.html of the app.
-  win.loadURL(url.format({
-    pathname: path.join(__dirname, 'index.html'),
-    protocol: 'file:',
-    slashes: true
-  }));
+    // and load the index.html of the app.
+    win.loadURL(
+        url.format({
+            pathname: path.join(__dirname, "index.html"),
+            protocol: "file:",
+            slashes: true,
+        })
+    );
 
-  shortcutsInstance = new shortcuts(win, app);
-  shortcutsInstance.registerAllShortcuts();
+    shortcutsInstance = new shortcuts(win, app);
+    shortcutsInstance.registerAllShortcuts();
 
-  // Only send to tray on minimize if user is running with tray and minimizing to tray is allowed
-  win.on('minimize',function(event) {
-    if (config['tray-icon'] && config['minimize-to-tray']) {
-      event.preventDefault();
-      win.hide();
-    }
-  });
+    // Only send to tray on minimize if user is running with tray and minimizing to tray is allowed
+    win.on("minimize", function (event) {
+        if (config["tray-icon"] && config["minimize-to-tray"]) {
+            event.preventDefault();
+            win.hide();
+        }
+    });
 
-  win.on('close', function (event) {
-    if (app.forceQuit || !config['tray-icon'] || !config['close-to-tray']) {
-      // Do the default electron behaviour which is to close the main window
-      // In production build the app is not closed probably due to this bug - https://github.com/electron/electron/issues/10156
-      // call the app.quit() once again, it helps
-      app.forceQuit = true;
-      app.quit();
-      return;
-    }
+    win.on("close", function (event) {
+        if (app.forceQuit || !config["tray-icon"] || !config["close-to-tray"]) {
+            // Do the default electron behaviour which is to close the main window
+            // In production build the app is not closed probably due to this bug - https://github.com/electron/electron/issues/10156
+            // call the app.quit() once again, it helps
+            app.forceQuit = true;
+            app.quit();
+            return;
+        }
 
-    event.preventDefault();
-    win.hide();
-  });
+        event.preventDefault();
+        win.hide();
+    });
 
-  // manage size/position of the window
-  // so it can be restored next time
-  mainWindowState.manage(win);
-}
-
-function handleRedirect(e, url) {
-  // there may be some popups on the same page
-  if (url == win.webContents.getURL()) {
-    return true;
-  }
-
-  // when user is logged in there is link
-  // asks to update the page. It should be opened
-  // in the app and not in the external browser
-  if (/https:\/\/todoist\.com\/app/.test(url)) {
-    win.reload();
-    return true;
-  }
-
-  /**
-   * In case of google or facebook oauth login
-   * let's create another window and listen for
-   * its "close" event.
-   * As soon as that event fired we can refresh our
-   * main window.
-   */
-  if (/google.+?oauth/.test(url) || /facebook.+?oauth/.test(url)) {
-    e.preventDefault();
-    gOauthWindow = new BrowserWindow();
-    gOauthWindow.loadURL(url);
-    gOauthWindow.on('close', () => {
-      win.reload();
-    })
-    return true;
-  }
-
-  /*
-   * The first time the settings button is clicked
-   * the 'new-window' event is emitted with the url to the settings page
-   * The electron default behavior(creating a new window) is prevented
-   * and instead the contents of the main window are reloaded with the contents
-   * from the settings page effectively emulating the behavior of the website
-   */
-  if (/prefs\/account/.test(url)) {
-    e.preventDefault();
-    win.loadURL(url);
-    return true;
-  }
-
-  e.preventDefault()
-  shell.openExternal(url)
+    // manage size/position of the window
+    // so it can be restored next time
+    mainWindowState.manage(win);
 }
 
 var gotTheLock = app.requestSingleInstanceLock();
 
 if (!gotTheLock) {
-  app.quit();
+    app.quit();
 } else {
-  app.on('second-instance', () => {
-    // Someone tried to run a second instance, we should focus our window.
-    if (win) {
-      if (win.isMinimized()){
-        win.restore();
-        win.focus();
-      }
-      win.show();
-      win.focus();
-    }
-  });
+    app.on("second-instance", () => {
+        // Someone tried to run a second instance, we should focus our window.
+        if (win) {
+            if (win.isMinimized()) {
+                win.restore();
+                win.focus();
+            }
+            win.show();
+            win.focus();
+        }
+    });
 }
 
-// app.on('ready', createWindow);
+app.on("ready", () => {
+    createWindow();
+    createTray(config);
 
-app.on('ready', () => {
-  createWindow();
-  createTray(config);
-
-  win.webContents.on('dom-ready', () => {
-    if (config['beta']) {
-      win.webContents.send('is-beta');
-    }
-  })
-})
-
+    win.webContents.on("dom-ready", () => {
+        if (config["beta"]) {
+            win.webContents.send("is-beta");
+        }
+    });
+});

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,5 @@
-const { app, BrowserWindow, Menu, session } = require("electron");
+const { app, BrowserWindow, Menu } = require("electron");
 const windowStateKeeper = require("electron-window-state");
-const shell = require("electron").shell;
 const path = require("path");
 const url = require("url");
 
@@ -8,23 +7,13 @@ const { ShortcutConfig } = require("./shortcutConfig");
 const createTray = require("./tray");
 const createMenuBar = require("./menuBar");
 const shortcuts = require("./shortcuts");
+const util = require("./util");
 
 let win = {};
-let gOauthWindow = undefined;
 let config = {};
 
-function setCustomUserAgent() {
-    session.defaultSession.webRequest.onBeforeSendHeaders(
-        (details, callback) => {
-            details.requestHeaders["User-Agent"] =
-                "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36";
-            callback({ cancel: false, requestHeaders: details.requestHeaders });
-        }
-    );
-}
-
 function createWindow() {
-    setCustomUserAgent();
+    util.setCustomUserAgent();
 
     const configInstance = new ShortcutConfig();
     config = configInstance.config;
@@ -90,23 +79,7 @@ function createWindow() {
     mainWindowState.manage(win);
 }
 
-var gotTheLock = app.requestSingleInstanceLock();
-
-if (!gotTheLock) {
-    app.quit();
-} else {
-    app.on("second-instance", () => {
-        // Someone tried to run a second instance, we should focus our window.
-        if (win) {
-            if (win.isMinimized()) {
-                win.restore();
-                win.focus();
-            }
-            win.show();
-            win.focus();
-        }
-    });
-}
+util.instanceLock();
 
 app.on("ready", () => {
     createWindow();

--- a/src/main.js
+++ b/src/main.js
@@ -11,132 +11,13 @@ const path = require('path');
 const url = require('url');
 
 const {ShortcutConfig} = require('./shortcutConfig');
+const createTray = require('./tray');
 const shortcuts = require('./shortcuts');
 
 let win = {};
 let gOauthWindow = undefined;
-let tray = null;
-let contextMenu;
 let config = {};
 
-function createTray() {
-  const configInstance = new ShortcutConfig();
-
-  // if tray-icon is set to null in config file then don't create a tray icon
-  if (!config['tray-icon']) {
-    return;
-  }
-
-  tray = new Tray(path.join(__dirname, `icons/${config['tray-icon']}`));
-  contextMenu = Menu.buildFromTemplate([
-    {
-      label: 'Open Todoist',
-      click:  function() {
-        win.show();
-      },
-      id: 'show-win'
-    },
-    {
-      type: 'separator'
-    },
-    {
-      label: 'Add task',
-      click:  function() {
-        win.webContents.sendInputEvent({
-          type: "keyDown",
-          keyCode: "Escape"
-        });
-        win.webContents.sendInputEvent({
-          type: "keyUp",
-          keyCode: "Escape"
-        });
-        win.webContents.sendInputEvent({
-          type: "char",
-          keyCode: 'q'
-        });
-        win.show();
-        win.webContents.send('focus-quick-add');
-      },
-      id: 'add-task'
-    },
-    {
-      label: 'Search',
-      click:  function() {
-        win.webContents.sendInputEvent({
-          type: "keyDown",
-          keyCode: "Escape"
-        });
-        win.webContents.sendInputEvent({
-          type: "keyUp",
-          keyCode: "Escape"
-        });
-        win.webContents.sendInputEvent({
-          type: "char",
-          keyCode: 'f'
-        });
-        win.show();
-      },
-      id: 'search'
-    },
-    {
-      label: 'Inbox',
-      click:  function() {
-        win.show();
-        win.webContents.send('go-to-anchor', 'filter_inbox');
-      },
-      id: 'inbox'
-    },
-    {
-      label: 'Today',
-      click:  function() {
-        win.show();
-        win.webContents.send('go-to-anchor', 'filter_today');
-      },
-      id: 'today'
-    },
-    {
-      label: 'Upcoming',
-      click:  function() {
-        win.show();
-        win.webContents.send('go-to-anchor', 'filter_upcoming');
-      },
-      id: 'upcoming'
-    },
-    {
-      type: 'separator'
-    },
-    {
-      label: 'Preferences',
-      click:  function() {
-        shell.openItem(path.join(
-          configInstance.getConfigDirectory(),
-          '.todoist-linux.json'
-        ));
-      },
-      id: 'preferences'
-    },
-    {
-      label: 'Report an issue',
-      click:  function() {
-        shell.openExternal('https://github.com/KryDos/todoist-linux/issues/new');
-      },
-      id: 'report-issue'
-    },
-    {
-      type: 'separator'
-    },
-    {
-      label: 'Quit Todoist',
-      click:  function() {
-        app.forceQuit = true;
-        app.quit();
-      },
-      id: 'quit'
-    }
-  ]);
-  tray.setToolTip('Todoist');
-  tray.setContextMenu(contextMenu);
-}
 
 function setCustomUserAgent() {
   session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
@@ -366,7 +247,7 @@ if (!gotTheLock) {
 
 app.on('ready', () => {
   createWindow();
-  createTray();
+  createTray(config);
 
   win.webContents.on('dom-ready', () => {
     if (config['beta']) {

--- a/src/main.js
+++ b/src/main.js
@@ -38,7 +38,7 @@ function createWindow() {
     });
 
     win.webContents.setVisualZoomLevelLimits(1, 5);
-    Menu.setApplicationMenu(createMenuBar(config));
+    Menu.setApplicationMenu(createMenuBar(config, win));
 
     // and load the index.html of the app.
     win.loadURL(
@@ -79,11 +79,27 @@ function createWindow() {
     mainWindowState.manage(win);
 }
 
-util.instanceLock();
+var gotTheLock = app.requestSingleInstanceLock();
+
+if (!gotTheLock) {
+    app.quit();
+} else {
+    app.on("second-instance", () => {
+        // Someone tried to run a second instance, we should focus our window.
+        if (win) {
+            if (win.isMinimized()) {
+                win.restore();
+                win.focus();
+            }
+            win.show();
+            win.focus();
+        }
+    });
+}
 
 app.on("ready", () => {
     createWindow();
-    createTray(config);
+    createTray(config, win);
 
     win.webContents.on("dom-ready", () => {
         if (config["beta"]) {

--- a/src/menuBar.js
+++ b/src/menuBar.js
@@ -4,7 +4,7 @@ const path = require("path");
 
 const { ShortcutConfig } = require("./shortcutConfig");
 
-function createMenuBar(config) {
+function createMenuBar(config, win) {
     const configInstance = new ShortcutConfig();
 
     return Menu.buildFromTemplate([

--- a/src/menuBar.js
+++ b/src/menuBar.js
@@ -1,0 +1,102 @@
+const { app, Menu } = require("electron");
+const shell = require("electron").shell;
+const path = require("path");
+
+const { ShortcutConfig } = require("./shortcutConfig");
+
+function createMenuBar(config) {
+  const configInstance = new ShortcutConfig();
+
+  return Menu.buildFromTemplate([
+    {
+      label: "File",
+      submenu: [
+        {
+          label: "Preferences",
+          click: function () {
+            shell.openItem(
+              path.join(
+                configInstance.getConfigDirectory(),
+                ".todoist-linux.json"
+              )
+            );
+          },
+        },
+        {
+          label: "Quit",
+          click: function () {
+            app.forceQuit = true;
+            app.quit();
+          },
+          accelerator: config["quit"],
+        },
+      ],
+    },
+    {
+      label: "View",
+      submenu: [
+        {
+          label: "Actual Size",
+          role: "resetzoom",
+          accelerator: "CommandOrControl+0",
+        },
+        {
+          label: "Zoom In",
+          role: "zoomin",
+          accelerator: "CommandOrControl+=",
+        },
+        {
+          label: "Zoom Out",
+          role: "zoomout",
+          accelerator: "CommandOrControl+-",
+        },
+        {
+          type: "separator",
+        },
+        {
+          label: "Show/Hide",
+          click: function () {
+            win.hide();
+          },
+          accelerator: config["show-hide"],
+        },
+        {
+          label: "Refresh",
+          click: function () {
+            win.reload();
+          },
+          accelerator: config["refresh"],
+        },
+      ],
+    },
+    {
+      label: "Help",
+      submenu: [
+        {
+          label: "GitHub",
+          click: function () {
+            shell.openExternal("https://github.com/KryDos/todoist-linux");
+          },
+        },
+        {
+          label: "Changelog",
+          click: function () {
+            shell.openExternal(
+              "https://github.com/krydos/todoist-linux/releases"
+            );
+          },
+        },
+        {
+          label: "Report an issue",
+          click: function () {
+            shell.openExternal(
+              "https://github.com/KryDos/todoist-linux/issues/new"
+            );
+          },
+        },
+      ],
+    },
+  ]);
+}
+
+module.exports = createMenuBar;

--- a/src/menuBar.js
+++ b/src/menuBar.js
@@ -5,98 +5,100 @@ const path = require("path");
 const { ShortcutConfig } = require("./shortcutConfig");
 
 function createMenuBar(config) {
-  const configInstance = new ShortcutConfig();
+    const configInstance = new ShortcutConfig();
 
-  return Menu.buildFromTemplate([
-    {
-      label: "File",
-      submenu: [
+    return Menu.buildFromTemplate([
         {
-          label: "Preferences",
-          click: function () {
-            shell.openItem(
-              path.join(
-                configInstance.getConfigDirectory(),
-                ".todoist-linux.json"
-              )
-            );
-          },
+            label: "File",
+            submenu: [
+                {
+                    label: "Preferences",
+                    click: function () {
+                        shell.openItem(
+                            path.join(
+                                configInstance.getConfigDirectory(),
+                                ".todoist-linux.json"
+                            )
+                        );
+                    },
+                },
+                {
+                    label: "Quit",
+                    click: function () {
+                        app.forceQuit = true;
+                        app.quit();
+                    },
+                    accelerator: config["quit"],
+                },
+            ],
         },
         {
-          label: "Quit",
-          click: function () {
-            app.forceQuit = true;
-            app.quit();
-          },
-          accelerator: config["quit"],
-        },
-      ],
-    },
-    {
-      label: "View",
-      submenu: [
-        {
-          label: "Actual Size",
-          role: "resetzoom",
-          accelerator: "CommandOrControl+0",
-        },
-        {
-          label: "Zoom In",
-          role: "zoomin",
-          accelerator: "CommandOrControl+=",
-        },
-        {
-          label: "Zoom Out",
-          role: "zoomout",
-          accelerator: "CommandOrControl+-",
-        },
-        {
-          type: "separator",
-        },
-        {
-          label: "Show/Hide",
-          click: function () {
-            win.hide();
-          },
-          accelerator: config["show-hide"],
-        },
-        {
-          label: "Refresh",
-          click: function () {
-            win.reload();
-          },
-          accelerator: config["refresh"],
-        },
-      ],
-    },
-    {
-      label: "Help",
-      submenu: [
-        {
-          label: "GitHub",
-          click: function () {
-            shell.openExternal("https://github.com/KryDos/todoist-linux");
-          },
+            label: "View",
+            submenu: [
+                {
+                    label: "Actual Size",
+                    role: "resetzoom",
+                    accelerator: "CommandOrControl+0",
+                },
+                {
+                    label: "Zoom In",
+                    role: "zoomin",
+                    accelerator: "CommandOrControl+=",
+                },
+                {
+                    label: "Zoom Out",
+                    role: "zoomout",
+                    accelerator: "CommandOrControl+-",
+                },
+                {
+                    type: "separator",
+                },
+                {
+                    label: "Show/Hide",
+                    click: function () {
+                        win.hide();
+                    },
+                    accelerator: config["show-hide"],
+                },
+                {
+                    label: "Refresh",
+                    click: function () {
+                        win.reload();
+                    },
+                    accelerator: config["refresh"],
+                },
+            ],
         },
         {
-          label: "Changelog",
-          click: function () {
-            shell.openExternal(
-              "https://github.com/krydos/todoist-linux/releases"
-            );
-          },
+            label: "Help",
+            submenu: [
+                {
+                    label: "GitHub",
+                    click: function () {
+                        shell.openExternal(
+                            "https://github.com/KryDos/todoist-linux"
+                        );
+                    },
+                },
+                {
+                    label: "Changelog",
+                    click: function () {
+                        shell.openExternal(
+                            "https://github.com/krydos/todoist-linux/releases"
+                        );
+                    },
+                },
+                {
+                    label: "Report an issue",
+                    click: function () {
+                        shell.openExternal(
+                            "https://github.com/KryDos/todoist-linux/issues/new"
+                        );
+                    },
+                },
+            ],
         },
-        {
-          label: "Report an issue",
-          click: function () {
-            shell.openExternal(
-              "https://github.com/KryDos/todoist-linux/issues/new"
-            );
-          },
-        },
-      ],
-    },
-  ]);
+    ]);
 }
 
 module.exports = createMenuBar;

--- a/src/shortcutConfig.js
+++ b/src/shortcutConfig.js
@@ -1,104 +1,98 @@
-const CONFIG_FILE_NAME = '.todoist-linux.json'
+const CONFIG_FILE_NAME = ".todoist-linux.json";
 
-const {dialog} = require('electron')
-const fs = require('fs');
-const path = require('path');
-const { URL } = require('url');
+const { dialog } = require("electron");
+const fs = require("fs");
+const path = require("path");
+const { URL } = require("url");
 
 class ShortcutConfig {
-  constructor() {
-    this.config = {};
+    constructor() {
+        this.config = {};
 
-    if (this.checkIfConfigFileExists()) {
-      this.updateShortcutsFromConfigFile();
-    } else {
-      this.createDefaultConfigFile();
-      this.updateShortcutsFromConfigFile();
+        if (this.checkIfConfigFileExists()) {
+            this.updateShortcutsFromConfigFile();
+        } else {
+            this.createDefaultConfigFile();
+            this.updateShortcutsFromConfigFile();
+        }
+
+        this.mergeConfigWithDefaults();
     }
 
-    this.mergeConfigWithDefaults();
-  }
-
-  // Make sure all shortcuts are defined.
-  // In case some of them missed we will apply the default one
-  mergeConfigWithDefaults() {
-    this.config = Object.assign(this.getDefaultConfig(), this.config);
-  }
-
-  updateShortcutsFromConfigFile() {
-    const configPath = path.join(
-      this.getConfigDirectory(),
-      CONFIG_FILE_NAME
-    );
-
-    try {
-      this.config = JSON.parse(
-        fs.readFileSync(
-          new URL('file://' + configPath),
-          'utf8'
-        )
-      );
-    } catch (e) {
-      dialog.showMessageBox({
-        title: 'Config error',
-        message: 'There is error in configuration file. Please make sure it has proper JSON. Default shortcuts will be used.'
-      });
-      this.config = this.getDefaultConfig();
-    }
-  }
-
-  createDefaultConfigFile() {
-    const configPath = path.join(
-      this.getConfigDirectory(),
-      CONFIG_FILE_NAME
-    );
-
-    fs.writeFileSync(
-      configPath,
-      JSON.stringify(
-        this.getDefaultConfig(),
-        null,
-        4
-      )
-    );
-  }
-
-  getConfigDirectory() {
-    if (process.platform == 'win32') {
-      return process.env.HOMEDRIVE + process.env.HOMEPATH;
+    // Make sure all shortcuts are defined.
+    // In case some of them missed we will apply the default one
+    mergeConfigWithDefaults() {
+        this.config = Object.assign(this.getDefaultConfig(), this.config);
     }
 
-    // if possible save config in $XDG_CONFIG_HOME
-    // which is $HOME/.config by default
-    if (process.env.XDG_CONFIG_HOME) {
-      return process.env.XDG_CONFIG_HOME;
+    updateShortcutsFromConfigFile() {
+        const configPath = path.join(
+            this.getConfigDirectory(),
+            CONFIG_FILE_NAME
+        );
+
+        try {
+            this.config = JSON.parse(
+                fs.readFileSync(new URL("file://" + configPath), "utf8")
+            );
+        } catch (e) {
+            dialog.showMessageBox({
+                title: "Config error",
+                message:
+                    "There is error in configuration file. Please make sure it has proper JSON. Default shortcuts will be used.",
+            });
+            this.config = this.getDefaultConfig();
+        }
     }
 
-    return process.env.HOME + '/.config';
-  }
+    createDefaultConfigFile() {
+        const configPath = path.join(
+            this.getConfigDirectory(),
+            CONFIG_FILE_NAME
+        );
 
-  checkIfConfigFileExists() {
-    const configPath = path.join(
-      this.getConfigDirectory(),
-      CONFIG_FILE_NAME
-    );
-    return fs.existsSync(configPath);
-  }
-
-  getDefaultConfig() {
-    return {
-      'quick-add': 'CommandOrControl+Alt+a',
-      'show-hide': 'CommandOrControl+Alt+Q',
-      'refresh': 'CommandOrControl+Alt+r',
-      'beta': false,
-      'quit': 'Alt+F4',
-      'tray-icon': 'icon.png',
-      'minimize-to-tray': true,
-      'close-to-tray': true,
+        fs.writeFileSync(
+            configPath,
+            JSON.stringify(this.getDefaultConfig(), null, 4)
+        );
     }
-  }
+
+    getConfigDirectory() {
+        if (process.platform == "win32") {
+            return process.env.HOMEDRIVE + process.env.HOMEPATH;
+        }
+
+        // if possible save config in $XDG_CONFIG_HOME
+        // which is $HOME/.config by default
+        if (process.env.XDG_CONFIG_HOME) {
+            return process.env.XDG_CONFIG_HOME;
+        }
+
+        return process.env.HOME + "/.config";
+    }
+
+    checkIfConfigFileExists() {
+        const configPath = path.join(
+            this.getConfigDirectory(),
+            CONFIG_FILE_NAME
+        );
+        return fs.existsSync(configPath);
+    }
+
+    getDefaultConfig() {
+        return {
+            "quick-add": "CommandOrControl+Alt+a",
+            "show-hide": "CommandOrControl+Alt+Q",
+            refresh: "CommandOrControl+Alt+r",
+            beta: false,
+            quit: "Alt+F4",
+            "tray-icon": "icon.png",
+            "minimize-to-tray": true,
+            "close-to-tray": true,
+        };
+    }
 }
 
 module.exports = {
-  ShortcutConfig
+    ShortcutConfig,
 };

--- a/src/shortcuts.js
+++ b/src/shortcuts.js
@@ -1,73 +1,73 @@
-const { globalShortcut } = require('electron');
-const {ShortcutConfig} = require('./shortcutConfig');
+const { globalShortcut } = require("electron");
+const { ShortcutConfig } = require("./shortcutConfig");
 
 class shortcuts {
-  constructor(win, app) {
-    this.win = win;
-    this.app = app;
-    this.shortcutConfig = new ShortcutConfig();
-  }
+    constructor(win, app) {
+        this.win = win;
+        this.app = app;
+        this.shortcutConfig = new ShortcutConfig();
+    }
 
-  registerAllShortcuts() {
-    this.registerQuickAddShortcut();
-    this.registerShowHideShortcut();
-    this.registerReloadShortcut();
-    this.registerQuitShortcut();
-  }
+    registerAllShortcuts() {
+        this.registerQuickAddShortcut();
+        this.registerShowHideShortcut();
+        this.registerReloadShortcut();
+        this.registerQuitShortcut();
+    }
 
-  // open quick add popup
-  registerQuickAddShortcut() {
-    globalShortcut.register(this.shortcutConfig.config['quick-add'], () => {
-      this.win.webContents.sendInputEvent({
-        type: "keyDown",
-        keyCode: "Escape"
-      });
-      this.win.webContents.sendInputEvent({
-        type: "keyUp",
-        keyCode: "Escape"
-      });
-      this.win.webContents.sendInputEvent({
-        type: "char",
-        keyCode: 'q'
-      });
-      this.win.show();
-      this.win.webContents.send('focus-quick-add');
-    });
-  }
+    // open quick add popup
+    registerQuickAddShortcut() {
+        globalShortcut.register(this.shortcutConfig.config["quick-add"], () => {
+            this.win.webContents.sendInputEvent({
+                type: "keyDown",
+                keyCode: "Escape",
+            });
+            this.win.webContents.sendInputEvent({
+                type: "keyUp",
+                keyCode: "Escape",
+            });
+            this.win.webContents.sendInputEvent({
+                type: "char",
+                keyCode: "q",
+            });
+            this.win.show();
+            this.win.webContents.send("focus-quick-add");
+        });
+    }
 
-  // show/hide
-  registerShowHideShortcut() {
-    globalShortcut.register(this.shortcutConfig.config['show-hide'], () => {
-      if (!this.win.isFocused()) {
-        this.win.show();
-        this.win.focus();
-        return;
-      }
+    // show/hide
+    registerShowHideShortcut() {
+        globalShortcut.register(this.shortcutConfig.config["show-hide"], () => {
+            if (!this.win.isFocused()) {
+                this.win.show();
+                this.win.focus();
+                return;
+            }
 
-      this.win.hide();
-    });
-  }
+            this.win.hide();
+        });
+    }
 
-  // reload page
-  registerReloadShortcut() {
-    globalShortcut.register(this.shortcutConfig.config['refresh'], () => {
-      if (this.win.isFocused()) {
-        this.win.reload();
-      }
-    });
-  }
+    // reload page
+    registerReloadShortcut() {
+        globalShortcut.register(this.shortcutConfig.config["refresh"], () => {
+            if (this.win.isFocused()) {
+                this.win.reload();
+            }
+        });
+    }
 
-  registerQuitShortcut() {
-    globalShortcut.register(this.shortcutConfig.config['quit'], () => {
-      if(!this.win.isFocused()) {
-        return;
-      }
+    registerQuitShortcut() {
+        globalShortcut.register(this.shortcutConfig.config["quit"], () => {
+            if (!this.win.isFocused()) {
+                return;
+            }
 
-      // forceQuit is important for on('close') event where this variable is checked.
-      this.app.forceQuit = true;
-      this.app.quit();
-    });
-  }
+            // forceQuit is important for on('close') event where this variable is checked.
+            this.app.forceQuit = true;
+            this.app.quit();
+        });
+    }
 }
 
 module.exports = shortcuts;

--- a/src/tray.js
+++ b/src/tray.js
@@ -4,7 +4,7 @@ const path = require("path");
 
 const { ShortcutConfig } = require("./shortcutConfig");
 
-function createTray(config) {
+function createTray(config, win) {
     const configInstance = new ShortcutConfig();
 
     // if tray-icon is set to null in config file then don't create a tray icon

--- a/src/tray.js
+++ b/src/tray.js
@@ -5,121 +5,124 @@ const path = require("path");
 const { ShortcutConfig } = require("./shortcutConfig");
 
 function createTray(config) {
-  const configInstance = new ShortcutConfig();
+    const configInstance = new ShortcutConfig();
 
-  // if tray-icon is set to null in config file then don't create a tray icon
-  if (!config['tray-icon']) return;
+    // if tray-icon is set to null in config file then don't create a tray icon
+    if (!config["tray-icon"]) return;
 
-  let tray = new Tray(path.join(__dirname, `icons/${config["tray-icon"]}`));
-  let contextMenu = Menu.buildFromTemplate([
-    {
-      label: "Open Todoist",
-      click: function () {
-        win.show();
-      },
-      id: "show-win",
-    },
-    {
-      type: "separator",
-    },
-    {
-      label: "Add task",
-      click: function () {
-        win.webContents.sendInputEvent({
-          type: "keyDown",
-          keyCode: "Escape",
-        });
-        win.webContents.sendInputEvent({
-          type: "keyUp",
-          keyCode: "Escape",
-        });
-        win.webContents.sendInputEvent({
-          type: "char",
-          keyCode: "q",
-        });
-        win.show();
-        win.webContents.send("focus-quick-add");
-      },
-      id: "add-task",
-    },
-    {
-      label: "Search",
-      click: function () {
-        win.webContents.sendInputEvent({
-          type: "keyDown",
-          keyCode: "Escape",
-        });
-        win.webContents.sendInputEvent({
-          type: "keyUp",
-          keyCode: "Escape",
-        });
-        win.webContents.sendInputEvent({
-          type: "char",
-          keyCode: "f",
-        });
-        win.show();
-      },
-      id: "search",
-    },
-    {
-      label: "Inbox",
-      click: function () {
-        win.show();
-        win.webContents.send("go-to-anchor", "filter_inbox");
-      },
-      id: "inbox",
-    },
-    {
-      label: "Today",
-      click: function () {
-        win.show();
-        win.webContents.send("go-to-anchor", "filter_today");
-      },
-      id: "today",
-    },
-    {
-      label: "Upcoming",
-      click: function () {
-        win.show();
-        win.webContents.send("go-to-anchor", "filter_upcoming");
-      },
-      id: "upcoming",
-    },
-    {
-      type: "separator",
-    },
-    {
-      label: "Preferences",
-      click: function () {
-        shell.openItem(
-          path.join(configInstance.getConfigDirectory(), ".todoist-linux.json")
-        );
-      },
-      id: "preferences",
-    },
-    {
-      label: "Report an issue",
-      click: function () {
-        shell.openExternal(
-          "https://github.com/KryDos/todoist-linux/issues/new"
-        );
-      },
-      id: "report-issue",
-    },
-    {
-      type: "separator",
-    },
-    {
-      label: "Quit Todoist",
-      click: function () {
-        app.forceQuit = true;
-        app.quit();
-      },
-      id: "quit",
-    },
-  ]);
-  tray.setToolTip("Todoist");
-  tray.setContextMenu(contextMenu);
+    let tray = new Tray(path.join(__dirname, `icons/${config["tray-icon"]}`));
+    let contextMenu = Menu.buildFromTemplate([
+        {
+            label: "Open Todoist",
+            click: function () {
+                win.show();
+            },
+            id: "show-win",
+        },
+        {
+            type: "separator",
+        },
+        {
+            label: "Add task",
+            click: function () {
+                win.webContents.sendInputEvent({
+                    type: "keyDown",
+                    keyCode: "Escape",
+                });
+                win.webContents.sendInputEvent({
+                    type: "keyUp",
+                    keyCode: "Escape",
+                });
+                win.webContents.sendInputEvent({
+                    type: "char",
+                    keyCode: "q",
+                });
+                win.show();
+                win.webContents.send("focus-quick-add");
+            },
+            id: "add-task",
+        },
+        {
+            label: "Search",
+            click: function () {
+                win.webContents.sendInputEvent({
+                    type: "keyDown",
+                    keyCode: "Escape",
+                });
+                win.webContents.sendInputEvent({
+                    type: "keyUp",
+                    keyCode: "Escape",
+                });
+                win.webContents.sendInputEvent({
+                    type: "char",
+                    keyCode: "f",
+                });
+                win.show();
+            },
+            id: "search",
+        },
+        {
+            label: "Inbox",
+            click: function () {
+                win.show();
+                win.webContents.send("go-to-anchor", "filter_inbox");
+            },
+            id: "inbox",
+        },
+        {
+            label: "Today",
+            click: function () {
+                win.show();
+                win.webContents.send("go-to-anchor", "filter_today");
+            },
+            id: "today",
+        },
+        {
+            label: "Upcoming",
+            click: function () {
+                win.show();
+                win.webContents.send("go-to-anchor", "filter_upcoming");
+            },
+            id: "upcoming",
+        },
+        {
+            type: "separator",
+        },
+        {
+            label: "Preferences",
+            click: function () {
+                shell.openItem(
+                    path.join(
+                        configInstance.getConfigDirectory(),
+                        ".todoist-linux.json"
+                    )
+                );
+            },
+            id: "preferences",
+        },
+        {
+            label: "Report an issue",
+            click: function () {
+                shell.openExternal(
+                    "https://github.com/KryDos/todoist-linux/issues/new"
+                );
+            },
+            id: "report-issue",
+        },
+        {
+            type: "separator",
+        },
+        {
+            label: "Quit Todoist",
+            click: function () {
+                app.forceQuit = true;
+                app.quit();
+            },
+            id: "quit",
+        },
+    ]);
+    tray.setToolTip("Todoist");
+    tray.setContextMenu(contextMenu);
 }
 
 module.exports = createTray;

--- a/src/tray.js
+++ b/src/tray.js
@@ -1,0 +1,125 @@
+const { app, Tray, Menu } = require("electron");
+const shell = require("electron").shell;
+const path = require("path");
+
+const { ShortcutConfig } = require("./shortcutConfig");
+
+function createTray(config) {
+  const configInstance = new ShortcutConfig();
+
+  // if tray-icon is set to null in config file then don't create a tray icon
+  if (!config['tray-icon']) return;
+
+  let tray = new Tray(path.join(__dirname, `icons/${config["tray-icon"]}`));
+  let contextMenu = Menu.buildFromTemplate([
+    {
+      label: "Open Todoist",
+      click: function () {
+        win.show();
+      },
+      id: "show-win",
+    },
+    {
+      type: "separator",
+    },
+    {
+      label: "Add task",
+      click: function () {
+        win.webContents.sendInputEvent({
+          type: "keyDown",
+          keyCode: "Escape",
+        });
+        win.webContents.sendInputEvent({
+          type: "keyUp",
+          keyCode: "Escape",
+        });
+        win.webContents.sendInputEvent({
+          type: "char",
+          keyCode: "q",
+        });
+        win.show();
+        win.webContents.send("focus-quick-add");
+      },
+      id: "add-task",
+    },
+    {
+      label: "Search",
+      click: function () {
+        win.webContents.sendInputEvent({
+          type: "keyDown",
+          keyCode: "Escape",
+        });
+        win.webContents.sendInputEvent({
+          type: "keyUp",
+          keyCode: "Escape",
+        });
+        win.webContents.sendInputEvent({
+          type: "char",
+          keyCode: "f",
+        });
+        win.show();
+      },
+      id: "search",
+    },
+    {
+      label: "Inbox",
+      click: function () {
+        win.show();
+        win.webContents.send("go-to-anchor", "filter_inbox");
+      },
+      id: "inbox",
+    },
+    {
+      label: "Today",
+      click: function () {
+        win.show();
+        win.webContents.send("go-to-anchor", "filter_today");
+      },
+      id: "today",
+    },
+    {
+      label: "Upcoming",
+      click: function () {
+        win.show();
+        win.webContents.send("go-to-anchor", "filter_upcoming");
+      },
+      id: "upcoming",
+    },
+    {
+      type: "separator",
+    },
+    {
+      label: "Preferences",
+      click: function () {
+        shell.openItem(
+          path.join(configInstance.getConfigDirectory(), ".todoist-linux.json")
+        );
+      },
+      id: "preferences",
+    },
+    {
+      label: "Report an issue",
+      click: function () {
+        shell.openExternal(
+          "https://github.com/KryDos/todoist-linux/issues/new"
+        );
+      },
+      id: "report-issue",
+    },
+    {
+      type: "separator",
+    },
+    {
+      label: "Quit Todoist",
+      click: function () {
+        app.forceQuit = true;
+        app.quit();
+      },
+      id: "quit",
+    },
+  ]);
+  tray.setToolTip("Todoist");
+  tray.setContextMenu(contextMenu);
+}
+
+module.exports = createTray;

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,33 @@
+const { app, session } = require("electron");
+
+function setCustomUserAgent() {
+    session.defaultSession.webRequest.onBeforeSendHeaders(
+        (details, callback) => {
+            details.requestHeaders["User-Agent"] =
+                "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36";
+            callback({ cancel: false, requestHeaders: details.requestHeaders });
+        }
+    );
+}
+
+function instanceLock() {
+    var gotTheLock = app.requestSingleInstanceLock();
+
+    if (!gotTheLock) {
+        app.quit();
+    } else {
+        app.on("second-instance", () => {
+            // Someone tried to run a second instance, we should focus our window.
+            if (win) {
+                if (win.isMinimized()) {
+                    win.restore();
+                    win.focus();
+                }
+                win.show();
+                win.focus();
+            }
+        });
+    }
+}
+
+module.exports = { setCustomUserAgent, instanceLock };

--- a/src/util.js
+++ b/src/util.js
@@ -1,4 +1,4 @@
-const { app, session } = require("electron");
+const { session } = require("electron");
 
 function setCustomUserAgent() {
     session.defaultSession.webRequest.onBeforeSendHeaders(
@@ -10,24 +10,4 @@ function setCustomUserAgent() {
     );
 }
 
-function instanceLock() {
-    var gotTheLock = app.requestSingleInstanceLock();
-
-    if (!gotTheLock) {
-        app.quit();
-    } else {
-        app.on("second-instance", () => {
-            // Someone tried to run a second instance, we should focus our window.
-            if (win) {
-                if (win.isMinimized()) {
-                    win.restore();
-                    win.focus();
-                }
-                win.show();
-                win.focus();
-            }
-        });
-    }
-}
-
-module.exports = { setCustomUserAgent, instanceLock };
+module.exports = { setCustomUserAgent };


### PR DESCRIPTION
`main.js` is getting too big, especially with the new menuBar and tray entries. This PR refactors `main.js` into several smaller JS files. 

Specifically:
- Tray and menuBar get separate JS files
- customeUserAgent is now in `util.js`
- I couldn't find any place in the project where `handleRedirect` was being used, so I removed it.

I've also added a [Prettier](https://prettier.io/) config for standardizing file formatting. 

Since this PR is more subjective, please let me know if anything should be changed or reverted. Also, while I've done my own testing to find and resolve refactoring bugs, I still feel that other people should test out this PR to ensure there are no bugs.