### PR TITLE
Menubar improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Same config file `.todoist-linux.json` has other options to configure the app:
 - `tray-icon` - tray icon to use. Possible options: `icon.png`, `icon_monochrome.png`, `null` (to hide tray icon completely)
 - `minimize-to-tray` - default is `true`. When window is minimized it goes to the tray.
 - `close-to-tray` - default is `true`. When window is closed the app is minimized to the tray.
+- `toggle-menubar` - default is `false`. When `true`, zoom in/out functionality is enabled and a menubar is togglable using <kbd>Alt</kbd>. 
 
 ## Why?
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Same config file `.todoist-linux.json` has other options to configure the app:
 - `tray-icon` - tray icon to use. Possible options: `icon.png`, `icon_monochrome.png`, `null` (to hide tray icon completely)
 - `minimize-to-tray` - default is `true`. When window is minimized it goes to the tray.
 - `close-to-tray` - default is `true`. When window is closed the app is minimized to the tray.
-- `toggle-menubar` - default is `false`. When `true`, zoom in/out functionality is enabled and a menubar is togglable using <kbd>Alt</kbd>. 
+- `toggle-menubar` - default is `true`. When `true`, zoom in/out functionality is enabled and a menubar is togglable using <kbd>Alt</kbd>. If you use the <kbd>Alt</kbd> + <kbd>Left Click</kbd> functionality of Todoist, you may want to disable this feature (this will also disable zoom functionality).
 
 ## Why?
 

--- a/src/main.js
+++ b/src/main.js
@@ -174,10 +174,17 @@ function createWindow () {
 
   var menuBar = Menu.buildFromTemplate([
     {
-      label: 'File',
+      label: '&File',
       submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { type: 'separator' },
         {
-          label: 'Preferences',
+          label: '&Preferences',
           click:  function() {
             shell.openItem(path.join(
               configInstance.getConfigDirectory(),
@@ -196,26 +203,26 @@ function createWindow () {
       ]
     },
     {
-      label: 'View',
+      label: '&View',
       submenu: [
         {
-          label:'Zoom In',
+          label:'Reload',
+          click:  function() {
+            win.reload();
+          },
+          accelerator: config['refresh']
+        },
+        { role: 'forcereload' },
+        { role: 'toggledevtools' },
+        { type: 'separator' },
+        { role: 'resetzoom' },
+        { 
           role: 'zoomin',
-          accelerator: 'CommandOrControl+='
+          accelerator: 'commandOrcontrol+='
         },
-        {
-          label:'Zoom Out',
-          role: 'zoomout',
-          accelerator: 'CommandOrControl+-'
-        },
-        {
-          label:'Reset Zoom',
-          role: 'resetzoom',
-          accelerator: 'CommandOrControl+0'
-        },
-        {
-          type: 'separator'
-        },
+        { role: 'zoomout' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
         {
           label:'Show/Hide',
           click:  function() {
@@ -223,17 +230,10 @@ function createWindow () {
           },
           accelerator: config['show-hide']
         },
-        {
-          label:'Refresh',
-          click:  function() {
-            win.reload();
-          },
-          accelerator: config['refresh']
-        },
       ]
     },
     {
-      label: 'Help',
+      label: '&Help',
       submenu: [
         {
           label: 'GitHub',
@@ -242,15 +242,15 @@ function createWindow () {
           },
         },
         {
-          label: 'Changelog',
-          click:  function() {
-            shell.openExternal('https://github.com/krydos/todoist-linux/releases');
-          },
-        },
-        {
           label: 'Report an issue',
           click:  function() {
             shell.openExternal('https://github.com/KryDos/todoist-linux/issues/new');
+          },
+        },
+        {
+          label: 'Changelog',
+          click:  function() {
+            shell.openExternal('https://github.com/krydos/todoist-linux/releases');
           },
         },
       ]

--- a/src/main.js
+++ b/src/main.js
@@ -167,7 +167,7 @@ function createWindow () {
     minWidth: 450,
     title: 'Todoist',
     icon: path.join(__dirname, 'icons/icon.png'),
-    autoHideMenuBar: true
+    autoHideMenuBar: config['toggle-menubar']
   });
 
   win.webContents.setVisualZoomLevelLimits(1, 5);
@@ -257,13 +257,9 @@ function createWindow () {
     },
   ])
 
-  if (!config['toggle-menubar']) {
-    win.autoHideMenuBar = false
-    win.setMenuBarVisibility(false)
-  }     
-  
   Menu.setApplicationMenu(menuBar);
-
+  win.setMenuBarVisibility(false) 
+  
   // and load the index.html of the app.
   win.loadURL(url.format({
     pathname: path.join(__dirname, 'index.html'),

--- a/src/main.js
+++ b/src/main.js
@@ -206,7 +206,7 @@ function createWindow () {
       label: '&View',
       submenu: [
         {
-          label:'Reload',
+          label:'&Reload',
           click:  function() {
             win.reload();
           },
@@ -224,7 +224,7 @@ function createWindow () {
         { type: 'separator' },
         { role: 'togglefullscreen' },
         {
-          label:'Show/Hide',
+          label:'&Show/Hide',
           click:  function() {
             win.hide();
           },
@@ -250,7 +250,7 @@ function createWindow () {
         {
           label: 'Changelog',
           click:  function() {
-            shell.openExternal('https://github.com/krydos/todoist-linux/releases');
+            shell.openExternal('https://github.com/KryDos/todoist-linux/releases');
           },
         },
       ]

--- a/src/main.js
+++ b/src/main.js
@@ -257,6 +257,11 @@ function createWindow () {
     },
   ])
 
+  if (!config['toggle-menubar']) {
+    win.autoHideMenuBar = false
+    win.setMenuBarVisibility(false)
+  }     
+  
   Menu.setApplicationMenu(menuBar);
 
   // and load the index.html of the app.

--- a/src/package.json
+++ b/src/package.json
@@ -15,8 +15,8 @@
   "author": "Ruslan Bekenev <furyinbox@gmail.com>",
   "license": "ISC",
   "devDependencies": {
-    "electron": "^4.2.12",
-    "electron-packager": "^13.1.1"
+    "electron": "^10.1.5",
+    "electron-packager": "^15.1.0"
   },
   "dependencies": {
     "electron-window-state": "^5.0.3"

--- a/src/package.json
+++ b/src/package.json
@@ -15,8 +15,8 @@
   "author": "Ruslan Bekenev <furyinbox@gmail.com>",
   "license": "ISC",
   "devDependencies": {
-    "electron": "^10.1.5",
-    "electron-packager": "^15.1.0"
+    "electron": "^4.2.12",
+    "electron-packager": "^13.1.1"
   },
   "dependencies": {
     "electron-window-state": "^5.0.3"

--- a/src/shortcutConfig.js
+++ b/src/shortcutConfig.js
@@ -93,7 +93,7 @@ class ShortcutConfig {
       'beta': false,
       'quit': 'Alt+F4',
       'tray-icon': 'icon.png',
-      'toggle-menubar': false,
+      'toggle-menubar': true,
       'minimize-to-tray': true,
       'close-to-tray': true,
     }

--- a/src/shortcutConfig.js
+++ b/src/shortcutConfig.js
@@ -93,6 +93,7 @@ class ShortcutConfig {
       'beta': false,
       'quit': 'Alt+F4',
       'tray-icon': 'icon.png',
+      'toggle-menubar': false,
       'minimize-to-tray': true,
       'close-to-tray': true,
     }


### PR DESCRIPTION
This PR is intended to be a temporary fix for issue https://github.com/KryDos/todoist-linux/issues/125. Users can now enabled the menubar in the config, so those who use alt+click functionality won't be bothered by that bug anymore if they are willing to disable the menubar which offers them zoom in/out.

The menubar has also been updated to look more formalized compared to common electron menubars found in other applications.

~Finally, this PR also updates electron to v10.1.5 and electron-packager to v15.1.0. The reason being that we can't work with electron to fix upstream errors for https://github.com/KryDos/todoist-linux/issues/125 and https://github.com/KryDos/todoist-linux/issues/127 without using a current version of electron. From my testing, there are no issues resulting from these updates, but I would recommend @KryDos to set up some CI testing to cover all the bases.~

The electron upgrade introduces bugs. It will become a separate PR.