### PR TITLE
Added start-minimized option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Same config file `.todoist-linux.json` has other options to configure the app:
 -   `tray-icon` - tray icon to use. Possible options: `icon.png`, `icon_monochrome.png`, `null` (to hide tray icon completely)
 -   `minimize-to-tray` - default is `true`. When window is minimized it goes to the tray.
 -   `close-to-tray` - default is `true`. When window is closed the app is minimized to the tray.
+-   `start-minimized` - default is `false`. App is started minimized (in tray).
 
 ## Why?
 

--- a/src/main.js
+++ b/src/main.js
@@ -35,6 +35,7 @@ function createWindow() {
         title: "Todoist",
         icon: path.join(__dirname, "icons/icon.png"),
         autoHideMenuBar: true,
+        show: !(config["start-minimized"] === true),
     });
 
     win.webContents.setVisualZoomLevelLimits(1, 5);

--- a/src/menuBar.js
+++ b/src/menuBar.js
@@ -14,12 +14,7 @@ function createMenuBar(config, win) {
                 {
                     label: "Preferences",
                     click: function () {
-                        shell.openItem(
-                            path.join(
-                                configInstance.getConfigDirectory(),
-                                ".todoist-linux.json"
-                            )
-                        );
+                        shell.openItem(configInstance.getConfigFilename());
                     },
                 },
                 {

--- a/src/shortcutConfig.js
+++ b/src/shortcutConfig.js
@@ -26,14 +26,12 @@ class ShortcutConfig {
     }
 
     updateShortcutsFromConfigFile() {
-        const configPath = path.join(
-            this.getConfigDirectory(),
-            CONFIG_FILE_NAME
-        );
-
         try {
             this.config = JSON.parse(
-                fs.readFileSync(new URL("file://" + configPath), "utf8")
+                fs.readFileSync(
+                    new URL("file://" + this.getConfigFilename()),
+                    "utf8"
+                )
             );
         } catch (e) {
             dialog.showMessageBox({
@@ -46,13 +44,8 @@ class ShortcutConfig {
     }
 
     createDefaultConfigFile() {
-        const configPath = path.join(
-            this.getConfigDirectory(),
-            CONFIG_FILE_NAME
-        );
-
         fs.writeFileSync(
-            configPath,
+            this.getConfigFilename(),
             JSON.stringify(this.getDefaultConfig(), null, 4)
         );
     }
@@ -71,12 +64,12 @@ class ShortcutConfig {
         return process.env.HOME + "/.config";
     }
 
+    getConfigFilename() {
+        return path.join(this.getConfigDirectory(), CONFIG_FILE_NAME);
+    }
+
     checkIfConfigFileExists() {
-        const configPath = path.join(
-            this.getConfigDirectory(),
-            CONFIG_FILE_NAME
-        );
-        return fs.existsSync(configPath);
+        return fs.existsSync(this.getConfigFilename());
     }
 
     getDefaultConfig() {

--- a/src/shortcutConfig.js
+++ b/src/shortcutConfig.js
@@ -89,6 +89,7 @@ class ShortcutConfig {
             "tray-icon": "icon.png",
             "minimize-to-tray": true,
             "close-to-tray": true,
+            "start-minimized": false,
         };
     }
 }

--- a/src/tray.js
+++ b/src/tray.js
@@ -91,12 +91,7 @@ function createTray(config, win) {
         {
             label: "Preferences",
             click: function () {
-                shell.openItem(
-                    path.join(
-                        configInstance.getConfigDirectory(),
-                        ".todoist-linux.json"
-                    )
-                );
+                shell.openItem(configInstance.getConfigFilename());
             },
             id: "preferences",
         },


### PR DESCRIPTION
Just added a `start-minimized` option to `.todoist-linux.json` as requested by #43. The default value is `false`, of course, and it's implemented as an option to `BrowserWindow`.