### PR TITLE
Added start-in-tray option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Same config file `.todoist-linux.json` has other options to configure the app:
 - `tray-icon` - tray icon to use. Possible options: `icon.png`, `icon_monochrome.png`, `null` (to hide tray icon completely)
 - `minimize-to-tray` - default is `true`. When window is minimized it goes to the tray.
 - `close-to-tray` - default is `true`. When window is closed the app is minimized to the tray.
+- `start-in-tray` - default is `false`. App is started in tray.
 
 ## Why?
 

--- a/src/main.js
+++ b/src/main.js
@@ -167,7 +167,8 @@ function createWindow () {
     minWidth: 450,
     title: 'Todoist',
     icon: path.join(__dirname, 'icons/icon.png'),
-    autoHideMenuBar: true
+    autoHideMenuBar: true,
+    show: !(config["start-in-tray"] === true)
   });
 
   win.webContents.setVisualZoomLevelLimits(1, 5);

--- a/src/main.js
+++ b/src/main.js
@@ -108,10 +108,7 @@ function createTray() {
     {
       label: 'Preferences',
       click:  function() {
-        shell.openItem(path.join(
-          configInstance.getConfigDirectory(),
-          '.todoist-linux.json'
-        ));
+        shell.openItem(configInstance.getConfigFilename());
       },
       id: 'preferences'
     },
@@ -180,10 +177,7 @@ function createWindow () {
         {
           label: 'Preferences',
           click:  function() {
-            shell.openItem(path.join(
-              configInstance.getConfigDirectory(),
-              '.todoist-linux.json'
-            ));
+            shell.openItem(configInstance.getConfigFilename());
           },
         },
         {

--- a/src/shortcutConfig.js
+++ b/src/shortcutConfig.js
@@ -95,6 +95,7 @@ class ShortcutConfig {
       'tray-icon': 'icon.png',
       'minimize-to-tray': true,
       'close-to-tray': true,
+      'start-in-tray': false,
     }
   }
 }

--- a/src/shortcutConfig.js
+++ b/src/shortcutConfig.js
@@ -77,11 +77,15 @@ class ShortcutConfig {
     return process.env.HOME + '/.config';
   }
 
-  checkIfConfigFileExists() {
-    const configPath = path.join(
+  getConfigFilename() {
+    return path.join(
       this.getConfigDirectory(),
       CONFIG_FILE_NAME
     );
+  }
+
+  checkIfConfigFileExists() {
+    const configPath = this.getConfigFilename();
     return fs.existsSync(configPath);
   }
 

--- a/src/shortcutConfig.js
+++ b/src/shortcutConfig.js
@@ -26,10 +26,7 @@ class ShortcutConfig {
   }
 
   updateShortcutsFromConfigFile() {
-    const configPath = path.join(
-      this.getConfigDirectory(),
-      CONFIG_FILE_NAME
-    );
+    const configPath = this.getConfigFilename();
 
     try {
       this.config = JSON.parse(
@@ -48,10 +45,7 @@ class ShortcutConfig {
   }
 
   createDefaultConfigFile() {
-    const configPath = path.join(
-      this.getConfigDirectory(),
-      CONFIG_FILE_NAME
-    );
+    const configPath = this.getConfigFilename();
 
     fs.writeFileSync(
       configPath,


### PR DESCRIPTION
I'm recreating PR #130 due to a big change in master.

---

Just added a `start-in-tray` option to `.todoist-linux.json` as requested by #43. The default value is `false`, of course, and it's implemented as an option to `BrowserWindow`.

Moreover, I've created a method `ShortcutConfig.getConfigFilename()` that do what the name says.